### PR TITLE
feat: Integrate Pink adaptors and critic refinement loop into Visual-…

### DIFF
--- a/Visual-RFT-main/Visual-ARFT/src/visual_arft/src/open_r1/grpo_agent_search.py
+++ b/Visual-RFT-main/Visual-ARFT/src/visual_arft/src/open_r1/grpo_agent_search.py
@@ -39,7 +39,26 @@ class GRPOScriptArguments(ScriptArguments):
         default=3136,
         metadata={"help": "Minimum number of pixels for the image"},
     )
-    
+    # Pink adaptor arguments
+    adapter_llm_enable: bool = field(default=False, metadata={"help": "Enable LLM adaptors"})
+    adapter_llm_dim: int = field(default=8, metadata={"help": "Hidden dimension for LLM adaptors"})
+    adapter_llm_scale: float = field(default=1.0, metadata={"help": "Scale factor for LLM adaptors"})
+    adapter_llm_dropout: float = field(default=0.05, metadata={"help": "Dropout rate for LLM adaptors"})
+    adapter_vision_enable: bool = field(default=False, metadata={"help": "Enable vision adaptors"})
+    adapter_vision_dim: int = field(default=8, metadata={"help": "Hidden dimension for vision adaptors"})
+    adapter_vision_scale: float = field(default=1.0, metadata={"help": "Scale factor for vision adaptors"})
+    adapter_vision_dropout: float = field(default=0.05, metadata={"help": "Dropout rate for vision adaptors"})
+    adapter_attn: bool = field(default=True, metadata={"help": "Apply adaptors to attention layers"})
+    adapter_mlp: bool = field(default=False, metadata={"help": "Apply adaptors to MLP layers"})
+    adapter_non_linear: bool = field(default=False, metadata={"help": "Use non-linear activation in adaptors"})
+    # clip_select_layer is not directly used in Qwen2VL model loading with adaptors in the same way as PinkModel,
+    # as Qwen2VL handles its vision encoder internally. We include it for completeness if needed later.
+    clip_select_layer: int = field(default=-2, metadata={"help": "CLIP select layer (less relevant for Qwen2VL direct integration)"})
+    # Refinement loop arguments
+    enable_refinement_loop: bool = field(default=False, metadata={"help": "Enable refinement loop with critic."})
+    refinement_threshold_tau: float = field(default=0.5, metadata={"help": "Score threshold for refinement."})
+    max_refinement_loops: int = field(default=3, metadata={"help": "Maximum number of refinement loops."})
+
 def normalize(s):
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
@@ -281,6 +300,22 @@ def main(script_args, training_args, model_args):
         attn_implementation=model_args.attn_implementation,
         max_pixels=script_args.max_pixels,
         min_pixels=script_args.min_pixels,
+        # Pass Pink adaptor arguments
+        adapter_llm_enable=script_args.adapter_llm_enable,
+        adapter_llm_dim=script_args.adapter_llm_dim,
+        adapter_llm_scale=script_args.adapter_llm_scale,
+        adapter_llm_dropout=script_args.adapter_llm_dropout,
+        adapter_vision_enable=script_args.adapter_vision_enable,
+        adapter_vision_dim=script_args.adapter_vision_dim,
+        adapter_vision_scale=script_args.adapter_vision_scale,
+        adapter_vision_dropout=script_args.adapter_vision_dropout,
+        adapter_attn=script_args.adapter_attn,
+        adapter_mlp=script_args.adapter_mlp,
+        adapter_non_linear=script_args.adapter_non_linear,
+        # Pass refinement loop arguments
+        enable_refinement_loop=script_args.enable_refinement_loop,
+        refinement_threshold_tau=script_args.refinement_threshold_tau,
+        max_refinement_loops=script_args.max_refinement_loops,
     )
 
     # Train and push the model to the Hub

--- a/Visual-RFT-main/Visual-ARFT/src/visual_arft/src/pink/pink_adapted_adapter.py
+++ b/Visual-RFT-main/Visual-ARFT/src/visual_arft/src/pink/pink_adapted_adapter.py
@@ -1,0 +1,354 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+import math
+from typing import Dict, List, Callable, Any
+
+import transformers
+from transformers.models.llama.configuration_llama import LlamaConfig as LlamaConfigOriginal # Keep original for reference if needed
+# Qwen2 specific imports
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer, Qwen2Attention, Qwen2FlashAttention2, Qwen2SdpaAttention, Qwen2MLP, Qwen2RMSNorm
+
+# Qwen2VL specific imports
+from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLConfig, Qwen2VLVisionConfig # Assuming Qwen2VLViTConfig might be Qwen2VLVisionConfig
+from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLViTEncoderLayer, Qwen2VLViTAttention, Qwen2VLViTMLP # Assuming these class names
+
+from transformers.modeling_outputs import ModelOutput, BaseModelOutputWithPast
+# Remove direct CLIP and old LLaMA layer imports if Qwen2 versions are comprehensive
+# from transformers.models.clip.modeling_clip import CLIPAttention, CLIPConfig, CLIPEncoderLayer, CLIPMLP
+
+# Removing EVA ViT specific parts as they are not relevant for Qwen2VL
+# from .eva_vit import Attention as EvaAttention
+# import pink.model.eva_vit
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Union
+from torch.cuda.amp import autocast
+
+
+class AdapterLayer(nn.Module):
+    def __init__(
+        self, 
+        in_features,
+        hidden_dim=8, 
+        scale=1,
+        dropout=0.1,
+        non_linear=False
+    ):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.scale = scale
+        self.in_features = in_features
+        self.tune_adapter_a = nn.Linear(self.in_features, hidden_dim, bias=True)
+        self.tune_adapter_b = nn.Linear(hidden_dim, self.in_features, bias=True)
+        self.dropout = nn.Dropout(dropout)
+
+        if non_linear:
+            self.activate = nn.SiLU()
+        else:
+            self.activate = nn.Identity()
+
+    def train(self, mode: bool = True):
+        self.tune_adapter_a.train(mode)
+        self.tune_adapter_b.train(mode)
+        self.dropout.train(mode)
+
+    def forward(self, x):
+        previous_dtype = x.dtype
+        weight_dtype = self.tune_adapter_a.weight.data.dtype
+        down_x = self.tune_adapter_a(x.to(weight_dtype))
+        down_x = self.activate(down_x)
+        up_x = self.tune_adapter_b(self.dropout(down_x))
+        result = up_x.to(previous_dtype) + x
+        return result
+
+
+def mark_only_adapter_as_trainable(model: nn.Module, bias: str = 'none') -> None:
+    """Freeze all modules except LoRA's and depending on 'bias' value unfreezes bias weights.
+
+    Args:
+        model: model with LoRA layers
+        bias: 
+            ``"none"``: all bias weights will be frozen,
+            ``"lora_only"``: only bias weight for LoRA layers will be unfrozen,
+            ``"all"``: all bias weights will be unfrozen.
+
+    Raises:
+        NotImplementedError: if `bias` not in ["none", "lora_only", "all"]
+    """
+    # freeze all layers except LoRA's
+    for n, p in model.named_parameters():
+        if 'adapter_' not in n:
+            p.requires_grad = False
+        else:
+            p.data = p.data.float()
+            p.requires_grad = True
+
+    # depending on the `bias` value unfreeze bias weights
+    if bias == 'none':
+        return
+    elif bias == 'all':
+        for n, p in model.named_parameters():
+            if 'bias' in n:
+                p.requires_grad = True
+    else:
+        raise NotImplementedError
+
+@dataclass
+class AdapterConfig:
+    hidden_dim: int = 8
+    scale: float = 1.0
+    dropout: float = 0.1
+    adapter_attn: bool = True
+    adapter_mlp: bool = True
+    non_linear: bool = False
+
+
+# Adapted for Qwen2VL Vision Encoder Layer
+class Qwen2VLViTAdapterEncoderLayer(nn.Module):
+    adapter_config = None
+    def __init__(self, config: Qwen2VLVisionConfig): # Changed from CLIPConfig
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        # IMPORTANT: Qwen2VLViTEncoderLayer uses Qwen2VLViTAttention and Qwen2VLViTMLP.
+        # These need to be compatible with the original CLIPAttention/MLP structure if we reuse AdapterLayer logic directly
+        # or the AdapterLayer needs to be made more generic.
+        # For now, assuming Qwen2VLViTAttention and Qwen2VLViTMLP are constructor arguments to the original layer.
+        # This part requires careful verification against transformers source.
+        # If Qwen2VLViTEncoderLayer directly instantiates these, this adapter needs to replicate that.
+        self.self_attn = Qwen2VLViTAttention(config) # Changed from CLIPAttention
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps) # Common
+        self.mlp = Qwen2VLViTMLP(config) # Changed from CLIPMLP
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps) # Common
+
+        if self.adapter_config.adapter_attn:
+            self.adapter_attn = AdapterLayer(
+                self.embed_dim,
+                self.adapter_config.hidden_dim,
+                self.adapter_config.scale,
+                self.adapter_config.dropout,
+                self.adapter_config.non_linear,
+            )
+        if self.adapter_config.adapter_mlp:
+            self.adapter_mlp = AdapterLayer(
+                self.embed_dim,
+                self.adapter_config.hidden_dim,
+                self.adapter_config.scale,
+                self.adapter_config.dropout,
+                self.adapter_config.non_linear,
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        # Qwen2VLViTEncoderLayer forward signature might differ from CLIPEncoderLayer.
+        # Specifically, `causal_attention_mask` might not be used.
+        # The `forward` signature should match the original Qwen2VLViTEncoderLayer's forward signature.
+        # For now, keeping it similar to CLIP's for structure.
+        attention_mask: torch.Tensor,
+        output_attentions: Optional[bool] = False,
+        # Potentially other args like `head_mask`, `patch_embedding_indices` etc. if present in original
+    ) -> Tuple[torch.FloatTensor]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`): attention mask of size
+                `(batch, 1, tgt_len, src_len)` where padding elements are indicated by very large negative values.
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+        """
+        residual = hidden_states
+
+        hidden_states = self.layer_norm1(hidden_states)
+        if hasattr(self, "adapter_attn"):
+            assert self.adapter_config.adapter_attn
+            hidden_states = self.adapter_attn(hidden_states)
+
+        # The call to self.self_attn must match how the original Qwen2VLViTEncoderLayer calls its attention.
+        # It might not take `causal_attention_mask`.
+        attn_outputs = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            output_attentions=output_attentions,
+        )
+        hidden_states = attn_outputs[0] # Assuming attention output is a tuple with hidden_states as first element
+        attn_weights = attn_outputs[1] if output_attentions and len(attn_outputs) > 1 else None
+
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        if hasattr(self, "adapter_mlp"):
+            assert self.adapter_config.adapter_mlp
+            hidden_states = self.adapter_mlp(hidden_states)
+
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (attn_weights,)
+
+        return outputs
+
+
+# Removed EvaAdapterAttention and related eva_adapter context manager
+
+# Qwen2 specific attention classes
+QWEN2_ATTENTION_CLASSES = {
+    "eager": Qwen2Attention,
+    "flash_attention_2": Qwen2FlashAttention2,
+    "sdpa": Qwen2SdpaAttention,
+}
+
+
+# Adapted for Qwen2 Decoder Layer
+class Qwen2AdapterDecoderLayer(nn.Module):
+    adapter_config = None
+    def __init__(self, config: Qwen2Config, layer_idx: int): # Changed from LlamaConfig
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        # Qwen2 uses Qwen2Attention, Qwen2FlashAttention2, Qwen2SdpaAttention
+        self.self_attn = QWEN2_ATTENTION_CLASSES[config._attn_implementation](config=config, layer_idx=layer_idx)
+
+        self.mlp = Qwen2MLP(config) # Changed from LlamaMLP
+        self.input_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps) # Changed from LlamaRMSNorm
+        self.post_attention_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps) # Changed from LlamaRMSNorm
+        if self.adapter_config.adapter_attn:
+            self.adapter_attn = AdapterLayer(
+                self.hidden_size,
+                self.adapter_config.hidden_dim,
+                self.adapter_config.scale,
+                self.adapter_config.dropout,
+                self.adapter_config.non_linear,
+            )
+        if self.adapter_config.adapter_mlp:
+            self.adapter_mlp = AdapterLayer( # This AdapterLayer might need adjustment if Qwen2MLP has a different structure
+                self.hidden_size,
+                self.adapter_config.hidden_dim,
+                self.adapter_config.scale,
+                self.adapter_config.dropout,
+                # non_linear for MLP adapter is typically False or handled by MLP's activation
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`, *optional*):
+                attention mask of size `(batch_size, sequence_length)` if flash attention is used or `(batch_size, 1,
+                query_sequence_length, key_sequence_length)` if default attention is used.
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            use_cache (`bool`, *optional*):
+                If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding
+                (see `past_key_values`).
+            past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
+        """
+        residual = hidden_states
+
+        hidden_states = self.input_layernorm(hidden_states)
+        if self.adapter_config.adapter_attn:
+            hidden_states = self.adapter_attn(hidden_states)
+
+        # Self Attention
+        hidden_states, self_attn_weights, present_key_value = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        if self.adapter_config.adapter_mlp:
+            hidden_states = self.adapter_mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        if use_cache:
+            outputs += (present_key_value,)
+
+        return outputs
+
+
+@contextmanager
+def adapter(hidden_dim, scale, dropout, enabled: bool = True, non_linear=False, attn=True, mlp=False):
+    if not enabled:
+        yield
+        return
+
+    Qwen2AdapterDecoderLayer.adapter_config = AdapterConfig(hidden_dim=hidden_dim, scale=scale, dropout=dropout, non_linear=non_linear, adapter_attn=attn, adapter_mlp=mlp)
+    original_layer = Qwen2DecoderLayer # Target Qwen2 specific layer
+    
+    # Path to Qwen2DecoderLayer in transformers library
+    # Ensure this path is correct based on your transformers installation structure
+    # It's typically transformers.models.<model_name>.modeling_<model_name>
+    target_module_path = "transformers.models.qwen2.modeling_qwen2"
+    
+    try:
+        module = __import__(target_module_path, fromlist=['Qwen2DecoderLayer'])
+        original_layer_ref = getattr(module, 'Qwen2DecoderLayer')
+        setattr(module, 'Qwen2DecoderLayer', Qwen2AdapterDecoderLayer)
+        yield
+    finally:
+        if 'module' in locals() and 'original_layer_ref' in locals(): # Ensure module was imported
+            setattr(module, 'Qwen2DecoderLayer', original_layer_ref) # Restore original
+        elif enabled: # Only print warning if adapter was supposed to be enabled
+            print(f"Warning: Could not patch Qwen2DecoderLayer in {target_module_path}. Adapter not applied for LLM.")
+            yield # Still yield to not break context management
+
+
+@contextmanager
+def visual_adapter(hidden_dim, scale, dropout, attn=True, mlp=False, enabled: bool = True, non_linear=False):
+    if not enabled:
+        yield
+        return
+
+    Qwen2VLViTAdapterEncoderLayer.adapter_config = AdapterConfig(hidden_dim=hidden_dim, scale=scale, dropout=dropout, adapter_attn=attn, adapter_mlp=mlp, non_linear=non_linear) # non_linear for vision can also be True
+    
+    # Path to Qwen2VLViTEncoderLayer in transformers library
+    target_module_path = "transformers.models.qwen2_vl.modeling_qwen2_vl"
+
+    try:
+        module = __import__(target_module_path, fromlist=['Qwen2VLViTEncoderLayer'])
+        original_layer_ref = getattr(module, 'Qwen2VLViTEncoderLayer')
+        setattr(module, 'Qwen2VLViTEncoderLayer', Qwen2VLViTAdapterEncoderLayer)
+        yield
+    finally:
+        if 'module' in locals() and 'original_layer_ref' in locals(): # Ensure module was imported
+            setattr(module, 'Qwen2VLViTEncoderLayer', original_layer_ref) # Restore original
+        elif enabled: # Only print warning if adapter was supposed to be enabled
+            print(f"Warning: Could not patch Qwen2VLViTEncoderLayer in {target_module_path}. Adapter not applied for Vision.")
+            yield # Still yield to not break context management
+
+# Removed eva_adapter context manager

--- a/Visual-RFT-main/Visual-ARFT/src/visual_arft/tests/__init__.py
+++ b/Visual-RFT-main/Visual-ARFT/src/visual_arft/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Visual-RFT-main/Visual-ARFT/src/visual_arft/tests a Python package

--- a/Visual-RFT-main/Visual-ARFT/src/visual_arft/tests/test_integration_features.py
+++ b/Visual-RFT-main/Visual-ARFT/src/visual_arft/tests/test_integration_features.py
@@ -1,0 +1,416 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import torch # Required for tensor operations in trainer if not fully mocked
+import PIL.Image # For creating dummy image inputs
+
+# Imports from the application code
+# Adjust paths as necessary if tests are run from a different working directory
+# Assuming PYTHONPATH or similar is set up for these imports to work
+from visual_arft.src.open_r1.grpo_agent_search import GRPOScriptArguments
+from visual_arft.src.open_r1.trainer.grpo_trainer import Qwen2VLGRPOTrainer, placeholder_critic_evaluate, REFINEMENT_PROMPT_TEMPLATE
+from trl import GRPOConfig, ModelConfig # For instantiating trainer args
+
+# Dummy PIL Image for testing
+def create_dummy_image():
+    return PIL.Image.new('RGB', (60, 30), color = 'red')
+
+class TestIntegrationFeatures(unittest.TestCase):
+
+    def test_grpo_script_arguments_defaults(self):
+        """Task 4: Test GRPOScriptArguments default values."""
+        args = GRPOScriptArguments()
+        self.assertFalse(args.adapter_llm_enable)
+        self.assertEqual(args.adapter_llm_dim, 8)
+        self.assertFalse(args.adapter_vision_enable)
+        self.assertEqual(args.adapter_vision_dim, 8)
+        self.assertTrue(args.adapter_attn)
+        self.assertFalse(args.adapter_mlp)
+        
+        self.assertFalse(args.enable_refinement_loop)
+        self.assertEqual(args.refinement_threshold_tau, 0.5)
+        self.assertEqual(args.max_refinement_loops, 3)
+
+    def test_placeholder_critic_evaluate(self):
+        """Task 2: Test placeholder_critic_evaluate function."""
+        dummy_image = create_dummy_image()
+        
+        # Test empty answer
+        result = placeholder_critic_evaluate("question", dummy_image, "")
+        self.assertEqual(result["score"], 0.1)
+        self.assertEqual(result["critique"], "The answer is empty.")
+
+        # Test answer with "sorry"
+        result = placeholder_critic_evaluate("question", dummy_image, "I am sorry, I cannot answer.")
+        self.assertEqual(result["score"], 0.2)
+        self.assertEqual(result["critique"], "The answer is not confident or incomplete.")
+
+        # Test very short answer
+        result = placeholder_critic_evaluate("question", dummy_image, "Yes.")
+        self.assertEqual(result["score"], 0.4)
+        self.assertEqual(result["critique"], "The answer is very short, potentially lacking detail.")
+
+        # Test a "good" answer
+        result = placeholder_critic_evaluate("question", dummy_image, "This is a reasonable answer.")
+        self.assertEqual(result["score"], 0.9)
+        self.assertEqual(result["critique"], "Looks good.")
+
+    @patch('visual_arft.src.pink.pink_adapted_adapter.visual_adapter')
+    @patch('visual_arft.src.pink.pink_adapted_adapter.adapter')
+    @patch('transformers.Qwen2VLForConditionalGeneration.from_pretrained')
+    @patch('transformers.AutoProcessor.from_pretrained') # Also mock processor loading
+    def test_adaptor_loading_disabled(self, mock_auto_processor, mock_from_pretrained, mock_llm_adapter, mock_vision_adapter):
+        """Task 1, Case 1: Test adaptors disabled."""
+        mock_model_instance = MagicMock()
+        mock_processor_instance = MagicMock()
+        mock_processor_instance.tokenizer = MagicMock()
+        mock_processor_instance.tokenizer.pad_token_id = 0
+        mock_processor_instance.tokenizer.eos_token_id = 1
+        mock_processor_instance.image_processor = MagicMock()
+
+        mock_from_pretrained.return_value = mock_model_instance
+        mock_auto_processor.return_value = mock_processor_instance
+        
+        # LLM adapter should be a context manager
+        mock_llm_adapter_cm = MagicMock()
+        mock_llm_adapter.return_value = mock_llm_adapter_cm
+        
+        # Vision adapter should be a context manager
+        mock_vision_adapter_cm = MagicMock()
+        mock_vision_adapter.return_value = mock_vision_adapter_cm
+
+        training_args = GRPOConfig(output_dir="dummy_output")
+        
+        trainer = Qwen2VLGRPOTrainer(
+            model="Qwen/Qwen2-VL-Chat", # dummy path
+            reward_funcs=[], 
+            args=training_args,
+            adapter_llm_enable=False,
+            adapter_vision_enable=False
+        )
+        
+        # Check from_pretrained was called (it's always called)
+        mock_from_pretrained.assert_called()
+
+        # Assert context managers were entered with enabled=False or not at all if logic short-circuits
+        # Based on current adapter.py, they are called but 'enabled' flag inside context manager controls behavior.
+        mock_llm_adapter.assert_called_with(hidden_dim=unittest.mock.ANY, scale=unittest.mock.ANY, dropout=unittest.mock.ANY, enabled=False, non_linear=unittest.mock.ANY, attn=unittest.mock.ANY, mlp=unittest.mock.ANY)
+        mock_vision_adapter.assert_called_with(hidden_dim=unittest.mock.ANY, scale=unittest.mock.ANY, dropout=unittest.mock.ANY, attn=unittest.mock.ANY, mlp=unittest.mock.ANY, enabled=False, non_linear=unittest.mock.ANY)
+
+
+    @patch('visual_arft.src.pink.pink_adapted_adapter.visual_adapter')
+    @patch('visual_arft.src.pink.pink_adapted_adapter.adapter')
+    @patch('transformers.Qwen2VLForConditionalGeneration.from_pretrained')
+    @patch('transformers.AutoProcessor.from_pretrained')
+    def test_adaptor_loading_enabled(self, mock_auto_processor, mock_from_pretrained, mock_llm_adapter, mock_vision_adapter):
+        """Task 1, Case 2: Test adaptors enabled."""
+        mock_model_instance = MagicMock()
+        mock_processor_instance = MagicMock()
+        mock_processor_instance.tokenizer = MagicMock()
+        mock_processor_instance.tokenizer.pad_token_id = 0
+        mock_processor_instance.tokenizer.eos_token_id = 1
+        mock_processor_instance.image_processor = MagicMock()
+
+        mock_from_pretrained.return_value = mock_model_instance
+        mock_auto_processor.return_value = mock_processor_instance
+
+        mock_llm_adapter_cm = MagicMock()
+        mock_llm_adapter.return_value = mock_llm_adapter_cm
+        
+        mock_vision_adapter_cm = MagicMock()
+        mock_vision_adapter.return_value = mock_vision_adapter_cm
+
+        training_args = GRPOConfig(output_dir="dummy_output")
+        
+        trainer = Qwen2VLGRPOTrainer(
+            model="Qwen/Qwen2-VL-Chat",
+            reward_funcs=[],
+            args=training_args,
+            adapter_llm_enable=True,
+            adapter_llm_dim=16,
+            adapter_llm_scale=0.5,
+            adapter_llm_dropout=0.1,
+            adapter_vision_enable=True,
+            adapter_vision_dim=32,
+            adapter_vision_scale=0.8,
+            adapter_vision_dropout=0.03,
+            adapter_attn=False, # Test non-default
+            adapter_mlp=True,   # Test non-default
+            adapter_non_linear=True # Test non-default
+        )
+        
+        mock_from_pretrained.assert_called()
+        mock_llm_adapter.assert_called_with(hidden_dim=16, scale=0.5, dropout=0.1, enabled=True, non_linear=True, attn=False, mlp=True)
+        mock_vision_adapter.assert_called_with(hidden_dim=32, scale=0.8, dropout=0.03, attn=False, mlp=True, enabled=True, non_linear=True)
+
+
+    def _setup_refinement_loop_test(self, enable_loop, max_loops, tau):
+        """Helper to set up a minimal trainer for refinement loop tests."""
+        mock_model_instance = MagicMock()
+        mock_model_instance.warnings_issued = {} # prevent error in trainer init
+        
+        mock_processor_instance = MagicMock()
+        mock_processor_instance.tokenizer = MagicMock()
+        mock_processor_instance.tokenizer.pad_token_id = 0
+        mock_processor_instance.tokenizer.eos_token_id = 1
+        mock_processor_instance.eos_token_id = 1 # for Qwen2VLGRPOTrainer internal use
+        mock_processor_instance.image_processor = MagicMock()
+        mock_processor_instance.batch_decode = MagicMock(side_effect=lambda x, **kwargs: [f"decoded_{i}" for i in range(x.size(0))] if hasattr(x, 'size') else ["decoded_0"])
+        
+        # Mock processing_class call for refinement
+        mock_processor_instance_call_result = {
+            "input_ids": torch.tensor([[1,2,3]]), 
+            "attention_mask": torch.tensor([[1,1,1]]),
+            "pixel_values": torch.randn(1,3,224,224), # Dummy pixel values
+            "image_grid_thw": torch.tensor([[[1,1,1]]]) # Dummy image_grid_thw
+        }
+        mock_processor_instance.return_value = mock_processor_instance_call_result
+        
+        # Mock apply_chat_template if it's part of the processor or its tokenizer
+        if hasattr(mock_processor_instance, 'apply_chat_template'):
+            mock_processor_instance.apply_chat_template = MagicMock(return_value="formatted_prompt_for_reward")
+        if hasattr(mock_processor_instance.tokenizer, 'apply_chat_template'):
+            mock_processor_instance.tokenizer.apply_chat_template = MagicMock(return_value="formatted_prompt_for_reward")
+
+
+        training_args = GRPOConfig(output_dir="dummy_output", per_device_train_batch_size=1) # batch size 1 for simplicity
+
+        trainer = Qwen2VLGRPOTrainer(
+            model=mock_model_instance, # Pass the mocked model instance
+            reward_funcs=[], # No rewards needed for this control flow test
+            args=training_args,
+            processing_class=mock_processor_instance,
+            enable_refinement_loop=enable_loop,
+            max_refinement_loops=max_loops,
+            refinement_threshold_tau=tau
+        )
+        trainer.accelerator = MagicMock() # Mock accelerator
+        trainer.accelerator.device = torch.device('cpu')
+        
+        # Mock inputs for compute_loss
+        # `inputs` is a list of dicts, each dict represents a sample from the dataset
+        dummy_image = create_dummy_image()
+        # `prompts` (passed to compute_loss) are derived from `inputs[x]['prompt']`
+        # `prompts_text` are derived from `maybe_apply_chat_template(inputs[x]['prompt'], ...)`
+        # `images` are derived from `inputs[x]['image']`
+        
+        # Let's make `inputs` simpler for this test, assuming it's already been processed to some extent
+        # or that `maybe_apply_chat_template` and image processing work as expected.
+        # The key is that `prompts_text` and `images` are available.
+        
+        # Mocking the structure that Qwen2VLGRPOTrainer.compute_loss expects for 'inputs'
+        # Each item in 'inputs' list is a dictionary.
+        # 'prompt' key holds the conversational structure.
+        # 'image' key holds a PIL image.
+        # 'solution' key (or others) might be present for reward functions but not essential for refinement loop logic itself.
+        
+        # For simplicity, we'll mock what `compute_loss` uses: `prompts_text` and `images`.
+        # The `inputs` arg to `compute_loss` is a list of dicts.
+        # `prompts = [x["prompt"] for x in inputs]`
+        # `prompts_text = [maybe_apply_chat_template(example, self.processing_class)["prompt"] for example in inputs]`
+        # `images = [x["image"] for x in inputs]`
+
+        # To avoid mocking maybe_apply_chat_template, let's assume it returns the text directly
+        # and `inputs[0]['prompt']` is what it would take.
+        
+        # We need to provide `prompts_text` and `images` to the mocked `compute_loss` context
+        # `prompts_text` is a list of strings (batch_size)
+        # `images` is a list of PIL Images (batch_size)
+        # `inputs` for compute_loss should be a list of dicts, where each dict has 'prompt' and 'image'.
+        # The 'prompt' in inputs should be the structured conversational prompt.
+        
+        # Simplified inputs for compute_loss
+        # `prompts` (list of conversational dicts) and `images` (list of PIL Images) are extracted from `inputs`
+        # `prompts_text` (list of strings) is also extracted and processed.
+
+        # Let's prepare the direct inputs that the refinement loop will use
+        # from within the mocked compute_loss context.
+        # We'll patch `self.processing_class` directly on the trainer instance for more control.
+        trainer.processing_class = mock_processor_instance
+
+
+        return trainer, mock_model_instance # Return model to mock its generate method
+
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.placeholder_critic_evaluate')
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.unwrap_model_for_generation')
+    def test_refinement_loop_max_times(self, mock_unwrap_model, mock_critic):
+        """Task 3, Case 1: Loop runs max times."""
+        trainer, model_mock = self._setup_refinement_loop_test(enable_loop=True, max_loops=3, tau=0.8)
+        
+        # Mock the behavior of the unwrapped model's generate method
+        # Needs to handle initial generation and refinement generations
+        mock_unwrapped_model_instance = MagicMock()
+        # Initial generation (B*G sequences)
+        initial_generation_output = torch.tensor([[1,2,3,4,5]]) # Example token IDs, B*G = 1*1 for simplicity
+        # Refinement generations (1 sequence each time)
+        refined_generation_output1 = torch.tensor([[10,11,12,13,14]])
+        refined_generation_output2 = torch.tensor([[20,21,22,23,24]])
+        refined_generation_output3 = torch.tensor([[30,31,32,33,34]])
+        
+        mock_unwrapped_model_instance.generate = MagicMock(side_effect=[
+            initial_generation_output, 
+            refined_generation_output1, 
+            refined_generation_output2, 
+            refined_generation_output3
+        ])
+        mock_unwrap_model.return_value.__enter__.return_value = mock_unwrapped_model_instance
+
+        mock_critic.return_value = {"score": 0.5, "critique": "Needs more work."} # Always low score
+
+        # Simplified inputs for compute_loss
+        # `inputs` is a list of dicts.
+        # `prompts_text` is a list of strings.
+        # `images` is a list of PIL images.
+        # `prompt_inputs` are the tokenized versions of these.
+        
+        # We need to construct the `inputs` argument for `compute_loss`
+        # And also ensure that `prompt_inputs` are correctly formed for the first generation call
+        
+        # Let compute_loss run, it will use the mocked generate and critic
+        # We need to provide the initial `inputs` that `compute_loss` expects.
+        # These are constructed by the dataloader in a real scenario.
+        # For this test, we provide minimal `inputs`.
+        
+        # `prompts`: list of conversational dicts
+        # `prompts_text`: list of strings (processed from `prompts`)
+        # `images`: list of PIL Images
+        
+        # Mocking the data `compute_loss` would receive and process
+        # This setup is for a batch size of 1, num_generations = 1 for simplicity of tracking calls
+        trainer.num_generations = 1 
+        dummy_conv_prompt = [{"role": "user", "content": [{"type": "text", "text": "Original Question"}]}]
+        test_inputs = [{'prompt': dummy_conv_prompt, 'image': create_dummy_image()}]
+
+        # Mocking what self.processing_class(text=prompts_text, images=images, ...) would return
+        # This is for the *initial* generation inside compute_loss
+        trainer.processing_class.return_value = {
+            "input_ids": torch.tensor([[1,2]]), # Dummy tokenized initial prompt
+            "attention_mask": torch.tensor([[1,1]]),
+            "pixel_values": torch.randn(1,3,224,224),
+            "image_grid_thw": torch.tensor([[[1,1,1]]])
+        }
+        
+        trainer.compute_loss(model=model_mock, inputs=test_inputs)
+
+        self.assertEqual(mock_unwrapped_model_instance.generate.call_count, 1 + 3) # 1 initial + 3 refinement
+        self.assertEqual(mock_critic.call_count, 3)
+
+
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.placeholder_critic_evaluate')
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.unwrap_model_for_generation')
+    def test_refinement_loop_exits_early(self, mock_unwrap_model, mock_critic):
+        """Task 3, Case 2: Loop exits early on good score."""
+        trainer, model_mock = self._setup_refinement_loop_test(enable_loop=True, max_loops=3, tau=0.8)
+
+        mock_unwrapped_model_instance = MagicMock()
+        initial_generation_output = torch.tensor([[1,2,3,4,5]])
+        refined_generation_output1 = torch.tensor([[10,11,12,13,14]])
+        mock_unwrapped_model_instance.generate = MagicMock(side_effect=[initial_generation_output, refined_generation_output1])
+        mock_unwrap_model.return_value.__enter__.return_value = mock_unwrapped_model_instance
+        
+        mock_critic.side_effect = [
+            {"score": 0.5, "critique": "Needs more work."}, # First call: low score
+            {"score": 0.9, "critique": "Looks good!"}      # Second call: high score
+        ]
+
+        trainer.num_generations = 1
+        dummy_conv_prompt = [{"role": "user", "content": [{"type": "text", "text": "Original Question"}]}]
+        test_inputs = [{'prompt': dummy_conv_prompt, 'image': create_dummy_image()}]
+        trainer.processing_class.return_value = { # For initial generation
+            "input_ids": torch.tensor([[1,2]]), "attention_mask": torch.tensor([[1,1]]),
+            "pixel_values": torch.randn(1,3,224,224), "image_grid_thw": torch.tensor([[[1,1,1]]])
+        }
+
+        trainer.compute_loss(model=model_mock, inputs=test_inputs)
+
+        self.assertEqual(mock_unwrapped_model_instance.generate.call_count, 1 + 1) # 1 initial + 1 refinement
+        self.assertEqual(mock_critic.call_count, 2)
+
+
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.placeholder_critic_evaluate')
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.unwrap_model_for_generation')
+    def test_refinement_loop_disabled(self, mock_unwrap_model, mock_critic):
+        """Task 3, Case 3: Loop disabled."""
+        trainer, model_mock = self._setup_refinement_loop_test(enable_loop=False, max_loops=3, tau=0.8)
+
+        mock_unwrapped_model_instance = MagicMock()
+        initial_generation_output = torch.tensor([[1,2,3,4,5]])
+        mock_unwrapped_model_instance.generate = MagicMock(return_value=initial_generation_output)
+        mock_unwrap_model.return_value.__enter__.return_value = mock_unwrapped_model_instance
+
+        trainer.num_generations = 1
+        dummy_conv_prompt = [{"role": "user", "content": [{"type": "text", "text": "Original Question"}]}]
+        test_inputs = [{'prompt': dummy_conv_prompt, 'image': create_dummy_image()}]
+        trainer.processing_class.return_value = { # For initial generation
+            "input_ids": torch.tensor([[1,2]]), "attention_mask": torch.tensor([[1,1]]),
+            "pixel_values": torch.randn(1,3,224,224), "image_grid_thw": torch.tensor([[[1,1,1]]])
+        }
+        
+        trainer.compute_loss(model=model_mock, inputs=test_inputs)
+
+        self.assertEqual(mock_unwrapped_model_instance.generate.call_count, 1) # Only initial generation
+        mock_critic.assert_not_called()
+
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.placeholder_critic_evaluate')
+    @patch('visual_arft.src.open_r1.trainer.grpo_trainer.unwrap_model_for_generation')
+    def test_refinement_prompt_construction(self, mock_unwrap_model, mock_critic):
+        """Task 3, Case 4: Test prompt construction for refinement."""
+        trainer, model_mock = self._setup_refinement_loop_test(enable_loop=True, max_loops=1, tau=0.8)
+        
+        mock_unwrapped_model_instance = MagicMock()
+        initial_generation_output = torch.tensor([[1,2,3,4,5]]) # Corresponds to "decoded_0"
+        refined_generation_output = torch.tensor([[10,11,12,13,14]])
+        mock_unwrapped_model_instance.generate = MagicMock(side_effect=[initial_generation_output, refined_generation_output])
+        mock_unwrap_model.return_value.__enter__.return_value = mock_unwrapped_model_instance
+
+        mock_critic.return_value = {"score": 0.5, "critique": "Test Critique"}
+        
+        trainer.num_generations = 1
+        original_question_text = "This is the original question?"
+        # We need to ensure prompts_text in compute_loss gets this value.
+        # This means the mocked call to maybe_apply_chat_template should produce it.
+        # For simplicity, we'll ensure `prompts_text` within compute_loss has this.
+        # This is tricky because `prompts_text` is derived inside `compute_loss`.
+        # We can patch `maybe_apply_chat_template` or ensure `inputs` leads to this.
+        
+        # The `prompts_text` is derived from `inputs` using `maybe_apply_chat_template`.
+        # Let's mock `maybe_apply_chat_template` for this specific test.
+        with patch('visual_arft.src.open_r1.trainer.grpo_trainer.maybe_apply_chat_template', 
+                   return_value={"prompt": original_question_text}) as mock_apply_template:
+
+            dummy_conv_prompt = [{"role": "user", "content": [{"type": "text", "text": original_question_text}]}]
+            test_inputs = [{'prompt': dummy_conv_prompt, 'image': create_dummy_image()}]
+            
+            # Mock for initial prompt processing
+            trainer.processing_class.side_effect = [
+                { # Initial prompt_inputs
+                    "input_ids": torch.tensor([[1,2]]), "attention_mask": torch.tensor([[1,1]]),
+                    "pixel_values": torch.randn(1,3,224,224), "image_grid_thw": torch.tensor([[[1,1,1]]])
+                },
+                { # Refinement prompt_inputs
+                    "input_ids": torch.tensor([[10,11]]), "attention_mask": torch.tensor([[1,1]]),
+                    "pixel_values": torch.randn(1,3,224,224), "image_grid_thw": torch.tensor([[[1,1,1]]]) # new dummy pixel values
+                }
+            ]
+            # Mock for initial batch_decode
+            trainer.processing_class.batch_decode = MagicMock(side_effect=lambda ids, **kwargs: ["initial_answer_0"] if ids.equal(torch.tensor([[3,4,5]])) else ["refined_answer_0"])
+
+
+            trainer.compute_loss(model=model_mock, inputs=test_inputs)
+
+            mock_apply_template.assert_called() # Ensure our prompt text setup was hit.
+
+            # Check the arguments to the processing_class for the refinement call
+            # The first call to processing_class is for the initial prompts.
+            # The second call is for the refinement prompt.
+            self.assertTrue(trainer.processing_class.call_count >= 2)
+            refinement_call_args = trainer.processing_class.call_args_list[1][1] # kwargs of second call
+            
+            expected_refinement_text = REFINEMENT_PROMPT_TEMPLATE.format(
+                question_text=original_question_text,
+                initial_answer="initial_answer_0", # from the first batch_decode mock
+                critique="Test Critique"
+            )
+            self.assertEqual(refinement_call_args['text'][0], expected_refinement_text)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…ARFT

I've integrated Pink's LLM and visual encoder adaptors into the Visual-ARFT framework for use with Qwen2VL models and introduced an iterative refinement loop driven by a critic model.

Key Changes:

1.  **Pink Adaptor Integration:**
    *   I modified `grpo_agent_search.py` to include command-line arguments for enabling and configuring Pink's LLM and vision adaptors (dimensions, scales, dropout, etc.).
    *   I adapted Pink's original `adapter.py` (targeting LLaMA/CLIP) to create `pink_adapted_adapter.py`. This new version targets Qwen2-specific layers (`Qwen2DecoderLayer` and `Qwen2VLViTEncoderLayer`) for compatibility with `Qwen2VLForConditionalGeneration`.
    *   I updated `Qwen2VLGRPOTrainer` in `trainer/grpo_trainer.py` to use these adaptors during model loading, controlled by the new CLI arguments. The adaptors are applied using context managers around model instantiation.

2.  **Critic-Based Refinement Loop:**
    *   I added new CLI arguments (`enable_refinement_loop`, `refinement_threshold_tau`, `max_refinement_loops`) to `grpo_agent_search.py` to control the refinement process.
    *   I implemented a placeholder critic (`placeholder_critic_evaluate` in `grpo_trainer.py`) that provides scores and critiques based on simple rules. This allows testing the loop structure without a full critic LLM.
    *   I integrated a refinement loop into `Qwen2VLGRPOTrainer.compute_loss`. If enabled, the generator's initial output is evaluated by the critic. If the score is below a threshold, a new prompt (including your original question, initial answer, and critique) is constructed and fed back to the generator for a refined answer. This process can iterate up to `max_refinement_loops`.
    *   The final (potentially refined) answer is then used for reward calculation in the GRPO algorithm.

3.  **Unit Tests:**
    *   I added a new test suite in `tests/test_integration_features.py`.
    *   Tests cover:
        *   Default values for new script arguments.
        *   Correct behavior of the `placeholder_critic_evaluate` function.
        *   Proper application of Pink adaptors (enabled/disabled states and parameter passing) during model loading, using mocks.
        *   Control flow of the refinement loop (max iterations, early exit, disabled state) and correct prompt construction, using mocks for model generation and critic evaluation.

This work sets the stage for enhancing Visual-ARFT models with Pink's parameter-efficient adaptors and improving generation quality through iterative refinement. Further work may involve replacing the placeholder critic with a trained LLM and verifying/fine-tuning the Qwen2VL-specific adaptor layer implementations.